### PR TITLE
Allow later versions to be installed, and update urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.27
-mysqlclient==1.3.10
-requests==2.20
-urllib3==1.21.1
+Django>=1.11.27
+mysqlclient>=1.3.10
+requests>=2.20
+urllib3>=1.23


### PR DESCRIPTION
1) Change to have minimum required versions, so potentially the installer can pick non-vulnerable ones.
2) Update urllib3 minimum version due to vulnerability from a Snyk report.